### PR TITLE
Avoid SIGFPE when a zero-length read is encountered

### DIFF
--- a/clipper/fastq-lib.cpp
+++ b/clipper/fastq-lib.cpp
@@ -228,6 +228,9 @@ bool poorqual(int n, int l, const char *s, const char *q) {
         }
         quals[n].sum += sum;
         quals[n].ns += ns;
+        if (l == 0) { // Avoid SIGFPE when passed zero-length read.
+          return 1;
+        }
         int xmean = sum/l;
         if (quals[n].cnt < 20000) {
             // mean qual < 18 = junk


### PR DESCRIPTION
fastq-mcf core dumps when it encounters a zero-length read (e.g. caused by earlier read trimming tools). This PR flags such reads as poor quality, without crashing.
