### PR TITLE
Two patches for OSX portability

### DIFF
--- a/clipper/ea-bcl2fastq.cpp
+++ b/clipper/ea-bcl2fastq.cpp
@@ -290,7 +290,7 @@ int main (int argc, char **argv) {
             ++output_fnum;                        // output file number is sequential
             masks[i].rnum=output_fnum;            // save file number as "read number"
             if (usegz) {
-                outtmp = string_format("gzip -2 --rsyncable -c > %s.%d.fq.gz",out.c_str(),output_fnum); 
+                outtmp = string_format("gzip -2  -c > %s.%d.fq.gz",out.c_str(),output_fnum); 
                 fo=popenordie(outtmp.c_str(),"w");
             } else {
                 outtmp = string_format("%s.%d.fq",out.c_str(),output_fnum); 

--- a/clipper/fastq-lib.cpp
+++ b/clipper/fastq-lib.cpp
@@ -361,7 +361,7 @@ int getstr (char ** lineptr, size_t *n, FILE * stream, char terminator, int offs
 	 NUL-terminate the line buffer.  */
 
       assert(*n - nchars_avail == read_pos - *lineptr);
-      if (nchars_avail < 1)
+      if (nchars_avail < 2)
 	{
 	  if (*n > 64)
 	    *n *= 2;

--- a/clipper/fastq-lib.cpp
+++ b/clipper/fastq-lib.cpp
@@ -160,7 +160,7 @@ FILE *gzopen(const char *f, const char *m, bool*isgz) {
         if (!strcmp(ext,".gz")) {
             char *tmp=(char *)malloc(strlen(f)+100);
             if (strchr(m,'w')) {
-                    strcpy(tmp, "gzip -3 --rsyncable > '");
+                    strcpy(tmp, "gzip -3  > '");
                     strcat(tmp, f);
                     strcat(tmp, "'");
             } else {

--- a/clipper/mirna-quant.cpp
+++ b/clipper/mirna-quant.cpp
@@ -681,7 +681,7 @@ FILE *gzopen(const char *f, const char *m, bool*isgz) {
         if (!strcmp(fext(f),".gz")) {
                 char *tmp=(char *)malloc(strlen(f)+100);
                 if (strchr(m,'w')) {
-                        strcpy(tmp, "gzip --rsyncable > '");
+                        strcpy(tmp, "gzip  > '");
                         strcat(tmp, f);
                         strcat(tmp, "'");
                 } else {


### PR DESCRIPTION
1.  Apple's gzip does not support --rsyncable.  This causes five tests to fail on OSX, specifically join test 3, mcf tests 18-19, and multx tests 4-6.

  ```
$ head -n 4 t/tmp/mcf.t.*/test6.err
 gzip: unrecognized option `--rsyncable'
    Apple gzip 251
    usage: gzip [-123456789acdfhklLNnqrtVv] [-S .suffix] [<file> [<file> ...]]
     -1 --fast            fastest (worst) compression
```
One option is to replace apple's gzip 
https://www.drupal.org/node/1901508
this PR removes the ```--rsyncable``` option from gzip for portability.

2.  There is a problem with ```getline.c``` that fails to allocate memory for the null terminator when the line length is a multiple of 64.   After porting to OSX, one of the tests failed with corrupt fastq when successive calls to read_line overwrote and corrupted data already in the fq structure.  This was an off-by-one error in the test to see if getstr should allocate more memory.
