### PR TITLE
Avoid divide by zero in average length, std

### DIFF
--- a/clipper/fastq-join.cpp
+++ b/clipper/fastq-join.cpp
@@ -388,9 +388,17 @@ int main (int argc, char **argv) {
 
 
 	double dev = sqrt((((double)joincnt)*tlensq-pow((double)tlen,2)) / ((double)joincnt*((double)joincnt-1)) );
+	double avg = (double) tlen / (double) joincnt;
+	if(joincnt == 0) { 
+		dev = 0; 
+		avg = 0;
+		} 
+	if(joincnt == 1) { 
+		dev = 0; 
+		} 
 	printf("Total reads: %d\n", nrec);
 	printf("Total joined: %d\n", joincnt);
-	printf("Average join len: %.2f\n", (double) tlen / (double) joincnt);
+	printf("Average join len: %.2f\n", avg);
 	printf("Stdev join len: %.2f\n", dev);
     printf("Version: %s\n", VERSION);
 

--- a/clipper/t/out/join/test-phred.out
+++ b/clipper/t/out/join/test-phred.out
@@ -1,5 +1,5 @@
 Total reads: 1
 Total joined: 1
 Average join len: 50.00
-Stdev join len: -nan
+Stdev join len: 0.00
 Version: 1.01.759


### PR DESCRIPTION
One of the tests fails on some systems because of a divide-by-zero for one of the test datafiles. 
This fixes that test on those systems.