### PR TITLE
fix int type overflow

### DIFF
--- a/clipper/Makefile
+++ b/clipper/Makefile
@@ -5,6 +5,7 @@ CC=g++
 PREFIX?=/usr
 BINDIR?=$(PREFIX)/bin
 CFLAGS?=-O3 -I. 
+CXXFLAGS=-std=c++0x $(CFLAGS)
 # for debugging:
 # CFLAGS?=-g -I. 
 
@@ -70,7 +71,7 @@ $(PKG).${VER}-${REL}.tar.gz: $(PKG).tar.gz
 
 sparsehash: sparsehash-2.0.3
 	cd sparsehash-2.0.3; ./configure; make
-	mkdir sparsehash
+	mkdir -p sparsehash
 	cp -r sparsehash-2.0.3/src/sparsehash/* sparsehash/
 
 # why the libbam.a doesn't work?  not sure... *.o works
@@ -94,8 +95,11 @@ else
 	$(CC) $(CFLAGS) fastq-lib.cpp tidx/tidx-lib.cpp -o $@ $< -lgsl -lgslcblas
 endif
 
+fastq-multx: fastq-multx.cpp fastq-lib.cpp sparsehash
+	$(CC) $(CXXFLAGS) fastq-multx.cpp fastq-lib.cpp -o $@
+
 fastq-stats: fastq-stats.cpp fastq-lib.cpp gcModel.cpp sparsehash
-	$(CC) $(CFLAGS) fastq-lib.cpp gcModel.cpp -o $@ $<
+	$(CC) $(CXXFLAGS) fastq-lib.cpp gcModel.cpp -o $@ $<
 
 bam-filter:  bam-filter.cpp 
 	$(CC) $(CFLAGS) fastq-lib.cpp -o $@  $< -lbamtools 

--- a/clipper/fastq-multx.cpp
+++ b/clipper/fastq-multx.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 See "void usage" below for usage.
 
 */
-
+#include <cinttypes>
 #include "fastq-lib.h"
 
 #define MAX_BARCODE_NUM 6000
@@ -43,7 +43,7 @@ struct bc {
 	char *out[6];			// one output per input
 	FILE *fout[6];
 	bool gzout[6];
-	int cnt;			// count found
+	uint64_t cnt;			// count found
 	bool shifted;			// count found in 1-shifted position
 	char * dual;			// is this a dual-indexed barcode?  if so, this points to the second index.
 	int dual_n;			// length of dual
@@ -1072,9 +1072,9 @@ int main (int argc, char **argv) {
 
 	int j;
 	printf("Id\tCount\tFile(s)\n");
-	int tot=0;
+	uint64_t tot=0;
 	for (i=0;i<=bcnt;++i) {
-		printf("%s\t%d", bc[i].id.s, bc[i].cnt);
+		printf("%s\t%" PRIu64, bc[i].id.s, bc[i].cnt);
 		tot+=bc[i].cnt;
 		for (j=0;j<f_n;++j) {
 			if (bc[i].out[j])
@@ -1082,7 +1082,7 @@ int main (int argc, char **argv) {
 		}
 		printf("\n");
 	}
-	printf("total\t%d\n", tot);
+	printf("total\t%" PRIu64 "\n", tot);
 
     if (!io_ok)
         return 3;

--- a/clipper/fastq-stats.cpp
+++ b/clipper/fastq-stats.cpp
@@ -25,6 +25,7 @@ const char * VERSION = "1.01 $Id$";
 
 #include <ctype.h>
 #include <stdio.h>
+#include <cinttypes>
 
 void usage( FILE * f ) {
   fprintf( f,
@@ -153,7 +154,7 @@ int window = 2000000;
 int cyclemax = 35; 
 int gcCyclemax = 100; // to compare with fastqc, seq is rounded to nearest 100 to reduce # of gc models; for < 200 length, this is teh same as max=100
 float gcSum;
-int gcTotal;
+uint64_t gcTotal;
 
 int show_max = 10;
 bool debug = 0;
@@ -565,6 +566,8 @@ int main( int argc, char**argv ) {
 	
 	if(gc) {
         // put these where they belong
+		if (debug)
+			printf("gcTotal\t%" PRIu64 "\tgcSum\t%f\n\n", gcTotal, gcSum);
         printf("pct-gc cycle-max\t%d\n", gcCyclemax);
         printf("pct-gc mean\t%.2f\n", 100.0 * gcSum / gcTotal);
     }


### PR DESCRIPTION
We got a couple of bugs in fastq-multx, and fastq-stats because some variable defined as int can't hold the total numbers generated by NovaSeq 6000.

Change those variables' type to uint64_t to fix the bugs. There might be other int type variable that could cause overflow, too.